### PR TITLE
sparseCoder CMakeLists: include DL library

### DIFF
--- a/modules/sparseCoder/src/CMakeLists.txt
+++ b/modules/sparseCoder/src/CMakeLists.txt
@@ -20,7 +20,7 @@ if(SIFTGPU_FOUND)
    source_group("Header Files" FILES ${folder_header})
    include_directories(${PROJECT_SOURCE_DIR} ${SIFTGPU_INCLUDE_DIRS})
    add_executable(${PROJECTNAME} ${folder_source} ${folder_header})
-   target_link_libraries(${PROJECTNAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES} ${SIFTGPU_LIBRARIES})
+   target_link_libraries(${PROJECTNAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES} ${SIFTGPU_LIBRARIES} ${CMAKE_DL_LIBS})
    install(TARGETS ${PROJECTNAME} DESTINATION bin)   
 endif()
 


### PR DESCRIPTION
Otherwise compilation on Linux machines fails. 
DL library is needed for `dlopen` in https://github.com/robotology/himrep/blob/master/modules/sparseCoder/src/SiftGPU_Extractor.cpp
