### PR TITLE
use OpenGL on OS X

### DIFF
--- a/modules/sparseCoder/src/SiftGPU_Extractor.h
+++ b/modules/sparseCoder/src/SiftGPU_Extractor.h
@@ -4,7 +4,12 @@
 
 #include <opencv2/opencv.hpp>
 
-#include "GL/gl.h"
+#if defined(__APPLE__)
+   #include <OpenGL/gl.h>
+   #include <OpenGL/glu.h>
+#else
+   #include "GL/gl.h"
+#endif
 
 #if !defined(SIFTGPU_STATIC) && !defined(SIFTGPU_DLL_RUNTIME)
 // SIFTGPU_STATIC comes from compiler


### PR DESCRIPTION
On OSX OpenGL library needs to be included instead of GL.
