### PR TITLE
Memory Leak in linearClassifierModule

### DIFF
--- a/modules/linearClassifierModule/src/SVMLinear.cpp
+++ b/modules/linearClassifierModule/src/SVMLinear.cpp
@@ -185,6 +185,7 @@ double SVMLinear::predictModel(vector<double> features)
 
     double val=0;
     predict_values(modelLinearSVM,x,&val);
+    free(x);
     return val;
 
 }


### PR DESCRIPTION
I found out that linearClassifierModule is leaking memory. The leak occurs in the recognition mode. After some investigation I found the reason:
In SVMLinear::predictModel a array of feature_nodes is created but never gets freed after usage. Freeing the x variable after usage solved the problem for me.
