### PR TITLE
Change deprecated FowardPrefilled to Forward

### DIFF
--- a/modules/caffeCoder/src/CaffeFeatExtractor.hpp
+++ b/modules/caffeCoder/src/CaffeFeatExtractor.hpp
@@ -257,7 +257,7 @@ float CaffeFeatExtractor<Dtype>::extractBatch_multipleFeat(vector<cv::Mat> &imag
 
     for (int b=0; b<num_batches; b++)
     {
-        results = feature_extraction_net->ForwardPrefilled();
+        results = feature_extraction_net->Forward();
 
         for (int i = 0; i < num_features; ++i) {
 
@@ -392,7 +392,7 @@ float CaffeFeatExtractor<Dtype>::extractBatch_singleFeat(vector<cv::Mat> &images
 
     for (int b=0; b<num_batches; b++)
     {
-        results = feature_extraction_net->ForwardPrefilled();
+        results = feature_extraction_net->Forward();
 
         const caffe::shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net->blob_by_name(blob_names[0]);
 
@@ -484,7 +484,7 @@ float CaffeFeatExtractor<Dtype>::extract_multipleFeat(cv::Mat &image, vector< Bl
     // Run network and retrieve features!
 
     // depending on your net's architecture, the blobs will hold accuracy and/or labels, etc
-    std::vector<Blob<Dtype>*> results = feature_extraction_net->ForwardPrefilled();
+    std::vector<Blob<Dtype>*> results = feature_extraction_net->Forward();
 
     for (int f = 0; f < num_features; ++f) {
 
@@ -589,7 +589,7 @@ float CaffeFeatExtractor<Dtype>::extract_singleFeat(cv::Mat &image, Blob<Dtype> 
     // Run network and retrieve features!
 
     // depending on your net's architecture, the blobs will hold accuracy and/or labels, etc
-    std::vector<Blob<Dtype>*> results = feature_extraction_net->ForwardPrefilled();
+    std::vector<Blob<Dtype>*> results = feature_extraction_net->Forward();
 
     const caffe::shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net->blob_by_name(blob_names[0]);
 
@@ -724,7 +724,7 @@ float CaffeFeatExtractor<Dtype>::extractBatch_multipleFeat_1D(vector<cv::Mat> &i
 
     for (int b=0; b<num_batches; ++b)
     {
-        results = feature_extraction_net->ForwardPrefilled();
+        results = feature_extraction_net->Forward();
 
         for (int f = 0; f < num_features; ++f) {
 
@@ -863,7 +863,7 @@ float CaffeFeatExtractor<Dtype>::extractBatch_singleFeat_1D(vector<cv::Mat> &ima
 
     for (int b=0; b<num_batches; ++b)
     {
-        results = feature_extraction_net->ForwardPrefilled();
+        results = feature_extraction_net->Forward();
 
         const caffe::shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net->blob_by_name(blob_names[0]);
 
@@ -959,7 +959,7 @@ float CaffeFeatExtractor<Dtype>::extract_multipleFeat_1D(cv::Mat &image, vector<
     // Run network and retrieve features!
 
     // depending on your net's architecture, the blobs will hold accuracy and/or labels, etc
-    std::vector<Blob<Dtype>*> results = feature_extraction_net->ForwardPrefilled();
+    std::vector<Blob<Dtype>*> results = feature_extraction_net->Forward();
 
     for (int f = 0; f < num_features; ++f) {
 
@@ -1011,12 +1011,10 @@ float CaffeFeatExtractor<Dtype>::extract_singleFeat_1D(cv::Mat &image, vector<Dt
 
     if (timing)
     {
+        cudaEventCreate(&start);
+        cudaEventCreate(&stop);
 
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
-
-    cudaEventRecord(start, NULL);
-
+        cudaEventRecord(start, NULL);
     }
 
     // Initialize labels to zero
@@ -1063,7 +1061,7 @@ float CaffeFeatExtractor<Dtype>::extract_singleFeat_1D(cv::Mat &image, vector<Dt
     // Run network and retrieve features!
 
     // depending on your net's architecture, the blobs will hold accuracy and/or labels, etc
-    std::vector<Blob<Dtype>*> results = feature_extraction_net->ForwardPrefilled();
+    std::vector<Blob<Dtype>*> results = feature_extraction_net->Forward();
 
     const caffe::shared_ptr<Blob<Dtype> > feature_blob = feature_extraction_net->blob_by_name(blob_names[0]);
 
@@ -1084,7 +1082,6 @@ float CaffeFeatExtractor<Dtype>::extract_singleFeat_1D(cv::Mat &image, vector<Dt
 
     if (timing)
     {
-
         // Record the stop event
         cudaEventRecord(stop, NULL);
 


### PR DESCRIPTION
Hi,
this removes the Caffe warning that `ForwardPrefilled` is deprecated and `Forward` should be used instead.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-217212083%22%2C%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-217216235%22%2C%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-217254605%22%2C%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-217513241%22%2C%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-218412687%22%2C%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-218415335%22%2C%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-218416918%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/himrep/pull/17%23issuecomment-217212083%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20%40Tobias-Fischer%20%5Cr%5Cn%5Cr%5CnAre%20you%20having%20this%20warning%20only%20with%20the%20latest%20%60Caffe%60%3F%20Given%20that%20we%27re%20still%20supporting%20the%20old%20version%2C%20it%20might%20be%20that%20your%20modifications%20should%20go%20under%20a%20%60%23ifdef%60%20guard.%20I%27m%20just%20speculating.%5Cr%5Cn%5Cr%5Cn%40GiuliaP%20can%20better%20handle%20this%20PR.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-05T17%3A05%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3738070%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pattacini%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20a%20good%20point.%20%60ForwardPrefilled%60%20became%20deprecated%20back%20in%20February%3A%20https%3A//github.com/BVLC/caffe/commit/f88073aad81d8119dc9d62f882b8cb6d20c3b7ee%22%2C%20%22created_at%22%3A%20%222016-05-05T17%3A22%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20will%20work%20on%20this%20next%20monday%20since%20tomorrow%20I%20have%20a%20presentation.%20Before%20merging%20I%20would%20like%20to%20check%20that%20the%20features%20are%20extracted%20in%20the%20correct%20way%20%28e.g.%20sequentially%20in%20a%20stream%20and%20not%20for%20instance%20always%20the%20same%20feature%20repeatedly%29.%20Indeed%20I%20remember%20some%20subtle%20differences%20between%20the%20two%20calls%20and%20I%27m%20not%20sure%20whether%20just%20replacing%20one%20with%20the%20other%20is%20sufficient.%20I%20am%20also%20not%20sure%20whether%20just%20one%20version%20of%20code%20can%20be%20correct%20for%20both%20older%20and%20newer%20caffe%20or%20there%20is%20the%20need%20for%20a%20%60%23ifdef%60.%22%2C%20%22created_at%22%3A%20%222016-05-05T19%3A36%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6449556%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/GiuliaP%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40GiuliaP%3A%20In%20the%20latest%20version%20of%20Caffe%2C%20%60ForwardPrefilled%60%20just%20calls%20%60Forward%60%20%28besides%20outputting%20the%20deprecated%20message%29%2C%20and%20thus%20the%20two%20methods%20are%20equivalent.%20I%27m%20not%20sure%20about%20previous%20versions%20however.%22%2C%20%22created_at%22%3A%20%222016-05-06T17%3A52%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closing%20here%20seeing%20that%20a%20new%20PR%20is%20upcoming%20soon%20%28https%3A//github.com/robotology/himrep/issues/18%29%22%2C%20%22created_at%22%3A%20%222016-05-11T09%3A48%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20on%20this.%20Yesterday%20I%20didn%27t%20manage%20to%20conclude.%22%2C%20%22created_at%22%3A%20%222016-05-11T10%3A00%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6449556%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/GiuliaP%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20worries%20%28and%20no%20rush%20either%20%3A%29%20%29.%22%2C%20%22created_at%22%3A%20%222016-05-11T10%3A07%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5497832%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tobias-Fischer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/himrep/pull/17#issuecomment-217212083'>General Comment</a></b>
- <a href='https://github.com/pattacini'><img border=0 src='https://avatars.githubusercontent.com/u/3738070?v=3' height=16 width=16'></a> Hi @Tobias-Fischer
  Are you having this warning only with the latest `Caffe`? Given that we're still supporting the old version, it might be that your modifications should go under a `#ifdef` guard. I'm just speculating.
  @GiuliaP can better handle this PR.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> That's a good point. `ForwardPrefilled` became deprecated back in February: https://github.com/BVLC/caffe/commit/f88073aad81d8119dc9d62f882b8cb6d20c3b7ee
- <a href='https://github.com/GiuliaP'><img border=0 src='https://avatars.githubusercontent.com/u/6449556?v=3' height=16 width=16'></a> I will work on this next monday since tomorrow I have a presentation. Before merging I would like to check that the features are extracted in the correct way (e.g. sequentially in a stream and not for instance always the same feature repeatedly). Indeed I remember some subtle differences between the two calls and I'm not sure whether just replacing one with the other is sufficient. I am also not sure whether just one version of code can be correct for both older and newer caffe or there is the need for a `#ifdef`.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> @GiuliaP: In the latest version of Caffe, `ForwardPrefilled` just calls `Forward` (besides outputting the deprecated message), and thus the two methods are equivalent. I'm not sure about previous versions however.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> Closing here seeing that a new PR is upcoming soon (https://github.com/robotology/himrep/issues/18)
- <a href='https://github.com/GiuliaP'><img border=0 src='https://avatars.githubusercontent.com/u/6449556?v=3' height=16 width=16'></a> I'm on this. Yesterday I didn't manage to conclude.
- <a href='https://github.com/Tobias-Fischer'><img border=0 src='https://avatars.githubusercontent.com/u/5497832?v=3' height=16 width=16'></a> No worries (and no rush either :) ).

<a href='https://www.codereviewhub.com/robotology/himrep/pull/17?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/himrep/pull/17?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/himrep/pull/17'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
