### PR TITLE
Fix cv::/yarp::cv:: namespace clash

### DIFF
--- a/modules/caffeCoder/src/main.cpp
+++ b/modules/caffeCoder/src/main.cpp
@@ -74,7 +74,7 @@ private:
 
     // Data (common to all methods)
 
-    cv::Mat                       matImg;
+    ::cv::Mat                       matImg;
 
     Port                          port_out_img;
     Port                          port_out_code;
@@ -91,7 +91,7 @@ private:
 
     CaffeFeatExtractor<float>    *caffe_extractor;
 
-    void onRead(Image &img)
+    void onRead(ImageOf<PixelRgb> &img)
     {
 
     	// Read at specified rate
@@ -106,8 +106,8 @@ private:
 
             // Convert the image
 
-            cv::Mat tmp_mat=toCvMat(img);
-            cv::cvtColor(tmp_mat, matImg, CV_RGB2BGR);
+            ::cv::Mat tmp_mat=toCvMat(img);
+            ::cv::cvtColor(tmp_mat, matImg, CV_RGB2BGR);
 
             // Extract the feature vector
 


### PR DESCRIPTION
Fixes the following compile error:

```
/home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:77:5: error: reference to ‘cv’ is ambiguous
     cv::Mat                       matImg;
     ^
In file included from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core/base.hpp:58:0,
                 from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core.hpp:54,
                 from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/opencv.hpp:52,
                 from /home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:29:
/opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core/cvstd.hpp:65:1: note: candidates are: namespace cv { }
 {
 ^
In file included from /home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:43:0:
/usr/local/src/robot/install/yarp/include/yarp/cv/Cv.h:19:14: note:                 namespace yarp::cv { }
 namespace cv {
              ^
/home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp: In member function ‘virtual void CaffeCoderPort::onRead(yarp::sig::Image&)’:
/home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:109:13: error: reference to ‘cv’ is ambiguous
             cv::Mat tmp_mat=toCvMat(img);
             ^
In file included from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core/base.hpp:58:0,
                 from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core.hpp:54,
                 from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/opencv.hpp:52,
                 from /home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:29:
/opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core/cvstd.hpp:65:1: note: candidates are: namespace cv { }
 {
 ^
In file included from /home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:43:0:
/usr/local/src/robot/install/yarp/include/yarp/cv/Cv.h:19:14: note:                 namespace yarp::cv { }
 namespace cv {
              ^
/home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:110:13: error: reference to ‘cv’ is ambiguous
             cv::cvtColor(tmp_mat, matImg, CV_RGB2BGR);
             ^
In file included from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core/base.hpp:58:0,
                 from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core.hpp:54,
                 from /opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/opencv.hpp:52,
                 from /home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:29:
/opt/ros/kinetic/include/opencv-3.3.1-dev/opencv2/core/cvstd.hpp:65:1: note: candidates are: namespace cv { }
 {
 ^
In file included from /home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:43:0:
/usr/local/src/robot/install/yarp/include/yarp/cv/Cv.h:19:14: note:                 namespace yarp::cv { }
 namespace cv {
              ^
/home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:110:26: error: ‘tmp_mat’ was not declared in this scope
             cv::cvtColor(tmp_mat, matImg, CV_RGB2BGR);
                          ^
/home/tobias/robot/himrep/modules/caffeCoder/src/main.cpp:110:35: error: ‘matImg’ was not declared in this scope
             cv::cvtColor(tmp_mat, matImg, CV_RGB2BGR);
                                   ^
modules/caffeCoder/src/CMakeFiles/caffeCoder.dir/build.make:62: recipe for target 'modules/caffeCoder/src/CMakeFiles/caffeCoder.dir/main.cpp.o' failed
make[2]: *** [modules/caffeCoder/src/CMakeFiles/caffeCoder.dir/main.cpp.o] Error 1
CMakeFiles/Makefile2:182: recipe for target 'modules/caffeCoder/src/CMakeFiles/caffeCoder.dir/all' failed
make[1]: *** [modules/caffeCoder/src/CMakeFiles/caffeCoder.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2
```