### PR TITLE
Fix missing `onRead(Image&)` + fix color conversion issues

### DIFF
--- a/modules/caffeCoder/src/main.cpp
+++ b/modules/caffeCoder/src/main.cpp
@@ -91,7 +91,7 @@ private:
 
     CaffeFeatExtractor<float>    *caffe_extractor;
 
-    void onRead(ImageOf<PixelRgb> &img)
+    void onRead(Image &img)
     {
 
     	// Read at specified rate
@@ -105,9 +105,9 @@ private:
         {
 
             // Convert the image
-
-            ::cv::Mat tmp_mat=toCvMat(img);
-            ::cv::cvtColor(tmp_mat, matImg, CV_RGB2BGR);
+            ImageOf<PixelRgb> tmp_img;
+            tmp_img.copy(img);
+            matImg = toCvMat(tmp_img);
 
             // Extract the feature vector
 


### PR DESCRIPTION
This PR fixes two things at the same time:

- restore the old signature `onRead(Image&)` for the callback function, otherwise `onRead(ImageOf<PixelRgb>&)` introduced in https://github.com/robotology/himrep/commit/c68eb29a5668e559418d19a891691932d44bb93f is never called and the module doesn't work anymore.

- fix the image conversion so that images are in the correct format (RGB for YARP images and BGR for OpenCV images)